### PR TITLE
Add buf size const generic, remove nightly feature

### DIFF
--- a/src/displays.rs
+++ b/src/displays.rs
@@ -16,15 +16,17 @@ pub struct LPM013M126A<COLOR = Rgb111> {
 impl DisplaySpec for LPM013M126A {
     const WIDTH: u16 = 176;
     const HEIGHT: u16 = 176;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 2;
 
-    type Framebuffer = Framebuffer4Bit<{ Self::WIDTH }, { Self::HEIGHT }>;
+    type Framebuffer = Framebuffer4Bit<{ Self::WIDTH }, { Self::HEIGHT }, { Self::SIZE}>;
 }
 
 impl DisplaySpec for LPM013M126A<BinaryColor> {
     const WIDTH: u16 = 176;
     const HEIGHT: u16 = 176;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 8;
 
-    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, JDI>;
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, {Self::SIZE}, JDI>;
 }
 
 /// 0.85inch 8-color display
@@ -35,15 +37,17 @@ pub struct LPM009M360A<COLOR = Rgb111> {
 impl DisplaySpec for LPM009M360A {
     const WIDTH: u16 = 72;
     const HEIGHT: u16 = 144;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 2;
 
-    type Framebuffer = Framebuffer4Bit<{ Self::WIDTH }, { Self::HEIGHT }>;
+    type Framebuffer = Framebuffer4Bit<{ Self::WIDTH }, { Self::HEIGHT }, { Self::SIZE }>;
 }
 
 impl DisplaySpec for LPM009M360A<BinaryColor> {
     const WIDTH: u16 = 72;
     const HEIGHT: u16 = 144;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 8;
 
-    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, JDI>;
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, { Self::SIZE }, JDI>;
 }
 
 /// 0.56inch, 64x64 BW display, 13pin 0.3mm FPC
@@ -52,8 +56,9 @@ pub struct LS006B7DH01;
 impl DisplaySpec for LS006B7DH01 {
     const WIDTH: u16 = 64;
     const HEIGHT: u16 = 64;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 8;
 
-    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, Sharp>;
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, { Self::SIZE }, Sharp>;
 }
 
 /// 1.28inch, 128x128 BW display, 10pin 0.5mm FPC
@@ -62,8 +67,9 @@ pub struct LS013B7DH03;
 impl DisplaySpec for LS013B7DH03 {
     const WIDTH: u16 = 128;
     const HEIGHT: u16 = 128;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 8;
 
-    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, Sharp>;
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, { Self::SIZE }, Sharp>;
 }
 
 /// 2.8inch, 400x240 BW display, 10pin 0.5mm FPC
@@ -72,8 +78,9 @@ pub struct LS027B7DH01;
 impl DisplaySpec for LS027B7DH01 {
     const WIDTH: u16 = 400;
     const HEIGHT: u16 = 240;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 8;
 
-    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, Sharp>;
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, { Self::SIZE }, Sharp>;
 }
 
 /// 2.8inch, 400x240 BW display, 10pin 0.5mm FPC
@@ -82,6 +89,7 @@ pub struct LPM027M128C;
 impl DisplaySpec for LPM027M128C {
     const WIDTH: u16 = 400;
     const HEIGHT: u16 = 240;
+    const SIZE: usize = (Self::WIDTH as usize * Self::HEIGHT as usize) / 8;
 
-    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, JDI>;
+    type Framebuffer = FramebufferBW<{ Self::WIDTH }, { Self::HEIGHT }, { Self:: SIZE}, JDI>;
 }

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -55,26 +55,20 @@ impl sealed::DriverVariant for Sharp {}
 
 pub trait FramebufferType: OriginDimensions + DrawTarget + Default + sealed::FramebufferSpiUpdate {}
 
-pub struct Framebuffer4Bit<const WIDTH: u16, const HEIGHT: u16>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:,
+pub struct Framebuffer4Bit<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize>
 {
-    data: [u8; WIDTH as usize * HEIGHT as usize / 2],
+    data: [u8; SIZE],
     rotation: Rotation,
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> Default for Framebuffer4Bit<WIDTH, HEIGHT>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> Default for Framebuffer4Bit<WIDTH, HEIGHT, SIZE>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> sealed::FramebufferSpiUpdate for Framebuffer4Bit<WIDTH, HEIGHT>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> sealed::FramebufferSpiUpdate for Framebuffer4Bit<WIDTH, HEIGHT, SIZE>
 {
     // only burst update is supported
     fn update<SPI: SpiBus>(&self, spi: &mut SPI) -> Result<(), SPI::Error> {
@@ -91,13 +85,11 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> Framebuffer4Bit<WIDTH, HEIGHT>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> Framebuffer4Bit<WIDTH, HEIGHT, SIZE>
 {
     pub fn new() -> Self {
         Self {
-            data: [0; WIDTH as usize * HEIGHT as usize / 2],
+            data: [0; SIZE],
             rotation: Rotation::Deg0,
         }
     }
@@ -140,14 +132,11 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> FramebufferType for Framebuffer4Bit<WIDTH, HEIGHT> where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> FramebufferType for Framebuffer4Bit<WIDTH, HEIGHT, SIZE>
 {
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> OriginDimensions for Framebuffer4Bit<WIDTH, HEIGHT>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> OriginDimensions for Framebuffer4Bit<WIDTH, HEIGHT, SIZE>
 {
     fn size(&self) -> Size {
         match self.rotation {
@@ -157,10 +146,7 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> DrawTarget for Framebuffer4Bit<WIDTH, HEIGHT>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 2]:,
-{
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> DrawTarget for Framebuffer4Bit<WIDTH, HEIGHT, SIZE> {
     type Color = Rgb111;
 
     type Error = core::convert::Infallible;
@@ -199,31 +185,25 @@ where
     }
 }
 
-pub struct FramebufferBW<const WIDTH: u16, const HEIGHT: u16, TYPE: sealed::DriverVariant>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+pub struct FramebufferBW<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize, TYPE: sealed::DriverVariant>
 {
-    data: [u8; WIDTH as usize * HEIGHT as usize / 8],
+    data: [u8; SIZE],
     rotation: Rotation,
     _type: PhantomData<TYPE>,
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16, TYPE: sealed::DriverVariant> Default for FramebufferBW<WIDTH, HEIGHT, TYPE>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize, TYPE: sealed::DriverVariant> Default for FramebufferBW<WIDTH, HEIGHT, SIZE, TYPE>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16, TYPE: sealed::DriverVariant> FramebufferBW<WIDTH, HEIGHT, TYPE>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize, TYPE: sealed::DriverVariant> FramebufferBW<WIDTH, HEIGHT, SIZE, TYPE>
 {
     pub fn new() -> Self {
         Self {
-            data: [0; WIDTH as usize * HEIGHT as usize / 8],
+            data: [0; SIZE],
             rotation: Rotation::Deg0,
             _type: PhantomData,
         }
@@ -270,9 +250,7 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> sealed::FramebufferSpiUpdate for FramebufferBW<WIDTH, HEIGHT, JDI>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> sealed::FramebufferSpiUpdate for FramebufferBW<WIDTH, HEIGHT, SIZE, JDI>
 {
     fn update<SPI: SpiBus>(&self, spi: &mut SPI) -> Result<(), SPI::Error> {
         for i in 0..HEIGHT {
@@ -288,9 +266,7 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16> sealed::FramebufferSpiUpdate for FramebufferBW<WIDTH, HEIGHT, Sharp>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize> sealed::FramebufferSpiUpdate for FramebufferBW<WIDTH, HEIGHT, SIZE, Sharp>
 {
     fn update<SPI: SpiBus>(&self, spi: &mut SPI) -> Result<(), SPI::Error> {
         for i in 0..HEIGHT {
@@ -306,18 +282,15 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16, TYPE: sealed::DriverVariant> FramebufferType
-    for FramebufferBW<WIDTH, HEIGHT, TYPE>
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize, TYPE: sealed::DriverVariant> FramebufferType
+    for FramebufferBW<WIDTH, HEIGHT, SIZE, TYPE>
 where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
-    FramebufferBW<WIDTH, HEIGHT, TYPE>: sealed::FramebufferSpiUpdate,
+    FramebufferBW<WIDTH, HEIGHT, SIZE, TYPE>: sealed::FramebufferSpiUpdate,
 {
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16, TYPE: sealed::DriverVariant> OriginDimensions
-    for FramebufferBW<WIDTH, HEIGHT, TYPE>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize, TYPE: sealed::DriverVariant> OriginDimensions
+    for FramebufferBW<WIDTH, HEIGHT, SIZE, TYPE>
 {
     fn size(&self) -> Size {
         match self.rotation {
@@ -327,9 +300,7 @@ where
     }
 }
 
-impl<const WIDTH: u16, const HEIGHT: u16, TYPE: sealed::DriverVariant> DrawTarget for FramebufferBW<WIDTH, HEIGHT, TYPE>
-where
-    [(); WIDTH as usize * HEIGHT as usize / 8]:,
+impl<const WIDTH: u16, const HEIGHT: u16, const SIZE: usize, TYPE: sealed::DriverVariant> DrawTarget for FramebufferBW<WIDTH, HEIGHT, SIZE, TYPE>
 {
     type Color = BinaryColor;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 use core::ops::{Deref, DerefMut};
 
@@ -19,6 +18,7 @@ pub mod pixelcolor;
 pub trait DisplaySpec {
     const WIDTH: u16;
     const HEIGHT: u16;
+    const SIZE: usize; // Buffer size for the display
 
     type Framebuffer: FramebufferType;
 }


### PR DESCRIPTION
This PR adds a const `SIZE` to `DisplaySpec`, adds a const generic `SIZE` to both `Framebuffer4Bit` and `FramebufferBW`. 

For users, all display structs like `LPM013M126A` are used as before, no API changes, but the nightly feature is removed, making the crate compatible with the stable Rust.

The disadvantage of this PR is that when implementing new memory lcd's, the developer should specify the correct buffer size. 

But due to currently there are only two types of `Framebuffer`, so the `SIZE` can be calculated using either `(Self::WIDTH as usize * Self::HEIGHT as usize) / 8` or `(Self::WIDTH as usize * Self::HEIGHT as usize) / 2`, which I think is acceptable.